### PR TITLE
Temporarily build kubedock from source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kubedock"]
+	path = kubedock
+	url = https://github.com/joyrex2001/kubedock.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,31 @@
 FROM quay.io/devfile/base-developer-image:ubi8-latest AS build
+
+ENV GODIR=/usr/local/go APPDIR=/opt/app CGO_ENABLED=0
+
+USER 0
+
+RUN curl -sfL --retry 10 -o /tmp/go.tar.gz https://go.dev/dl/go1.21.1.linux-amd64.tar.gz && \
+    echo "b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae /tmp/go.tar.gz" | sha256sum -c && \
+    mkdir -p $GODIR && \
+    tar --strip-components=1 -zxf /tmp/go.tar.gz --directory $GODIR && \
+    rm /tmp/go.tar.gz && \
+    mkdir -p $APPDIR
+
+ENV PATH="$GODIR/bin:$PATH"
+
+WORKDIR $APPDIR/kubedock
+
+COPY . $APPDIR
+
+RUN CGO_ENABLED=0 go build -ldflags "\
+  -X github.com/joyrex2001/kubedock/internal/config.Date=`date -u +%Y%m%d-%H%M%S`\
+  -X github.com/joyrex2001/kubedock/internal/config.Build=`git rev-list -1 HEAD`\
+  -X github.com/joyrex2001/kubedock/internal/config.Version=`git describe --tags`\
+  -X github.com/joyrex2001/kubedock/internal/config.Image=joyrex2001/kubedock:`git describe --tags | cut -d- -f1`" \
+  -o kubedock
+
+FROM quay.io/devfile/base-developer-image:ubi8-latest
+
 LABEL maintainer="Red Hat, Inc."
 
 LABEL version="ubi8"
@@ -10,10 +37,7 @@ LABEL description="Kubedock image based on UBI8."
 
 USER 0
 
-# Install kubedock
-ENV KUBEDOCK_VERSION 0.13.0
-RUN curl -L https://github.com/joyrex2001/kubedock/releases/download/${KUBEDOCK_VERSION}/kubedock_${KUBEDOCK_VERSION}_linux_amd64.tar.gz | tar -C /usr/local/bin -xz \
-    && chmod +x /usr/local/bin/kubedock
+COPY --from=build /opt/app/kubedock/kubedock /usr/local/bin/kubedock
 
 ENTRYPOINT ["/usr/local/bin/kubedock"]
 CMD [ "server" ]

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,1 +1,8 @@
 #!/bin/bash
+
+set -exv
+
+IMAGE="quay.io/cloudservices/kubedock"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+docker build -t "${IMAGE}:${IMAGE_TAG}" .


### PR DESCRIPTION
In order to address CVE-2023-44487.

Once kubedock upstream has a release with the fix, we can revert these changes and update to the new release.